### PR TITLE
Improve German translation

### DIFF
--- a/src/intl/de.json
+++ b/src/intl/de.json
@@ -20,9 +20,9 @@
 		"shareLinkPassword": "Passwort für geteilten Link",
 		"expirationDate": "Ablaufdatum für geteilten Link",
 		"plainTextShareLink": "Geteilten Link kopieren und in Ihre Mail einfügen",
-		"attachFromNextcloud": "Anhängen von Nextcloud",
-		"attachedOK":"Dokument beigefügt!",
-		"linkInserted":"Link eingefügt!"
+		"attachFromNextcloud": "Aus Nextcloud anhängen",
+		"attachedOK": "Datei angehängt!",
+		"linkInserted": "Link eingefügt!"
 	},
 	"zimlet": {
 		"description": "Nextcloud integration for Zimbra",


### PR DESCRIPTION
- `attachFromNextcloud`: According to the source code change this translation is next to `attachInline` and `attachAsLink`, I assume the meaning is "Attach (how or from where)". If that applies, my suggested change should be more suitable.
- `attachedOK`:
  - "Dokument" ("Document") seems wrong, should be likely "Datei" ("File"); file is more general and also applies e.g. to image files rather than just to (word-processing or PDF) documents.
  - "beigefügt" ("attached") is the wrong German translation, given that an attachment is "Anhang" in German, "attached" becomes "angehängt".

As ZBUG-3313 was raised by a customer during one of my projects (and the previous improved German translation with commit 276510a145d918088c55b87d11a39eab71b1e80f results from the same project), I would like to cross-check my here proposed translation on Monday with the customer first. And afterwards this likely needs a fixed release…